### PR TITLE
Don't spend build time optimizing build-time-only crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ nanoserde = {version = "0.1", optional = true}
 
 bincode = { version = "1.3", optional = true }
 serde = {version = "1.0", features = ["derive"], optional = true }
+
+[profile.release.build-override]
+opt-level = 0


### PR DESCRIPTION
Crates used exclusively at build time, such as proc-macro crates and
their dependencies, don't benefit substantially from optimization; they
take far longer to optimize than time saved when running them during the
build. No machine code from these crates will appear in the final
compiled binary.

Use the new profile-overrides mechanism in Rust 1.41
(https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) to
build such crates with opt-level 0.

serde's derive feature uses proc macros, so this should speed up release
builds with serde considerably. This pull request does not attempt to
update the numbers in the README, since they wouldn't be on the same
machine used for the original benchmarks.